### PR TITLE
Fix custom instruments getting empty name and ID

### DIFF
--- a/src/nbs/file/fromArrayBuffer.ts
+++ b/src/nbs/file/fromArrayBuffer.ts
@@ -202,8 +202,9 @@ export function fromArrayBuffer(arrayBuffer: ArrayBuffer, options = defaultFromA
         for (let i = 0; i < customInstruments; i++) {
             song.instruments.loaded.push(
                 new Instrument(
-                    Number.parseInt(reader.readString()), // Read instrument name
+                    song.instruments.firstCustomIndex + i,
                     {
+                        "name": reader.readString(), // Read instrument name
                         "soundFile": reader.readString(), // Read instrument file
                         "key": reader.readByte(), // Read instrument pitch
                         "pressKey": Boolean(reader.readByte()) // Read press key status


### PR DESCRIPTION
# Prerequisites
<!-- Change [ ] to [x] to check the boxes -->
- [x] A similar pull request does not already exist, or this pull request supersedes an existing pull request.
- [x] The project's contributing and relevant documentation have been acknowledged and adhered to.
- [x] I have signed off all of my relevant commits.

Closes #8 

# Information
As per issue #8, during the parsing of an NBS file, custom instruments are generated that contain empty `meta.name` (empty string) and `id` (`NaN`) attributes. This results from the name string being read from the file, but not actually stored in the `name` attribute, which receives the default value `""` from the `defaultInstrumentOptions` object.

Additionally, as the first parameter to the `Instrument` object constructor is passed the return value of `Number.parseInt` called on the parsed string, which always results in `NaN`. As a result, this value is assigned to all custom instruments' `id` attributes.

This pull request fixes the issue by calculating the custom instrument's ID from the `firstCustomIndex` property and the index of the current instrument being read, and assigning the parsed name string to the `meta.name` property.